### PR TITLE
feat: Improved callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ After adding the gem to your application, run the install generator:
 This generator will add `cognito_idp` to your routes and install an initializer at `config/initializers/cognito_idp.rb`.
 
 Be sure to review and edit the initializer to configure options for your Amazon Cognito User Pool configuration. You
-must also provide an implementation for the `on_valid_login` function in the initializer appropriate for any actions you
+must also provide an implementation for the `after_login` function in the initializer appropriate for any actions you
 want to take when a user signed in.
 
 ## Development

--- a/app/controllers/cognito_idp_rails/sessions_controller.rb
+++ b/app/controllers/cognito_idp_rails/sessions_controller.rb
@@ -12,7 +12,7 @@ module CognitoIdpRails
       client.get_token(grant_type: :authorization_code, code: params[:code], redirect_uri: auth_login_callback_url) do |token|
         client.get_user_info(token) do |user_info|
           reset_session
-          configuration.on_valid_login.call(token, user_info, session)
+          configuration.after_login.call(token, user_info, request)
           redirect_to configuration.after_login_route, notice: "You have been successfully logged in."
           return
         end
@@ -25,7 +25,7 @@ module CognitoIdpRails
     end
 
     def logout_callback
-      configuration.on_logout.call(session)
+      configuration.before_logout.call(request)
       reset_session
       redirect_to configuration.after_logout_route, notice: "You have been successfully logged out."
     end

--- a/lib/cognito_idp_rails/configuration.rb
+++ b/lib/cognito_idp_rails/configuration.rb
@@ -1,13 +1,13 @@
 module CognitoIdpRails
   class Configuration
     attr_accessor :after_login_route, :after_logout_route, :domain, :client_id,
-      :client_secret, :on_logout, :on_valid_login, :scope
+      :client_secret, :after_login, :before_logout, :scope
 
     def initialize
       @after_login_route = "/"
       @after_logout_route = "/"
-      @on_valid_login = lambda { |token, user_info, session| }
-      @on_logout = lambda { |session| }
+      @after_login = lambda { |token, user_info, request| }
+      @before_logout = lambda { |request| }
     end
   end
 end

--- a/lib/generators/cognito_idp_rails/templates/cognito_idp_rails_initializer.rb.tt
+++ b/lib/generators/cognito_idp_rails/templates/cognito_idp_rails_initializer.rb.tt
@@ -2,16 +2,16 @@ CognitoIdpRails.configure do |config|
   config.client_id = ENV["COGNITO_CLIENT_ID"]
   config.client_secret = ENV["COGNITO_CLIENT_SECRET"]
   config.domain = ENV["COGNITO_DOMAIN"]
-  config.on_valid_login = lambda do |token, user_info, session|
+  config.after_login = lambda do |token, user_info, request|
     # 1. Find or create a user.
     # user = User.where(identifier: user_info.sub).first_or_create do |user|
     #   user.email = user_info.email
     # end
 
     # 2. Set any session data for the user.
-    # session[:user_id] = user.id
+    # request.session[:user_id] = user.id
   end
-  config.on_logout = lambda do |session|
+  config.before_logout = lambda do |request|
     # Your last chance to do something before the session is reset.
   end
 end

--- a/spec/cognito_idp_rails/configuration_spec.rb
+++ b/spec/cognito_idp_rails/configuration_spec.rb
@@ -87,35 +87,35 @@ RSpec.describe CognitoIdpRails::Configuration do
     end
   end
 
-  describe "#on_logout" do
-    subject(:on_logout) { configuration.on_logout }
+  describe "#after_login" do
+    subject(:after_login) { configuration.after_login }
 
     it { is_expected.to be_a(Proc) }
 
     context "when specified" do
       before do
-        configuration.on_logout = new_on_logout
+        configuration.after_login = new_after_login
       end
 
-      let(:new_on_logout) { instance_double(Proc) }
+      let(:new_after_login) { instance_double(Proc) }
 
-      it { is_expected.to eq(new_on_logout) }
+      it { is_expected.to eq(new_after_login) }
     end
   end
 
-  describe "#on_valid_login" do
-    subject(:on_valid_login) { configuration.on_valid_login }
+  describe "#before_logout" do
+    subject(:before_logout) { configuration.before_logout }
 
     it { is_expected.to be_a(Proc) }
 
     context "when specified" do
       before do
-        configuration.on_valid_login = new_on_valid_login
+        configuration.before_logout = new_before_logout
       end
 
-      let(:new_on_valid_login) { instance_double(Proc) }
+      let(:new_before_logout) { instance_double(Proc) }
 
-      it { is_expected.to eq(new_on_valid_login) }
+      it { is_expected.to eq(new_before_logout) }
     end
   end
 


### PR DESCRIPTION
Callbacks are now named better and provide access to the request instead
of the session. Requests are more useful than sessions and still provide
access to the session should you need it.

The `on_valid_login` callback has been renamed to `after_login` and the
session is replaced with a request object. For example:
```ruby
config.after_login = lambda do |token, user_info, request|
  user = User.where(identifier: user_info.sub).first_or_create do |user|
    user.email = user_info.email
  end
  request.session[:user_id] = user.id
end
```

The `on_logout` callback has been renamed to `before_logout` and the
session is replaced with a request object. For example:
```ruby
config.before_logout = lambda do |request|
  # Your last chance to do something before the session is reset.
end
```

BREAKING CHANGE: The callback signatures have changed. Initializers must
be updated.
