### PR TITLE
feat: Upgrade to cognito_idp 1.0

### DIFF
--- a/app/controllers/cognito_idp_rails/sessions_controller.rb
+++ b/app/controllers/cognito_idp_rails/sessions_controller.rb
@@ -9,14 +9,12 @@ module CognitoIdpRails
     end
 
     def login_callback
-      client.get_token(grant_type: :authorization_code, code: params[:code], redirect_uri: auth_login_callback_url) do |token|
-        client.get_user_info(token) do |user_info|
-          reset_session
-          configuration.after_login.call(token, user_info, request)
-          redirect_to configuration.after_login_route, notice: "You have been successfully logged in."
-          return
-        end
-      end
+      token = client.get_token(grant_type: :authorization_code, code: params[:code], redirect_uri: auth_login_callback_url)
+      user_info = client.get_user_info(token)
+      reset_session
+      configuration.after_login.call(token, user_info, request)
+      redirect_to configuration.after_login_route, notice: "You have been successfully logged in."
+    rescue CognitoIdp::Error
       redirect_to configuration.after_login_route, notice: "Login failed."
     end
 

--- a/cognito_idp_rails.gemspec
+++ b/cognito_idp_rails.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
     Dir["{app,config,db,lib}/**/*", "LICENSE", "Rakefile", "README.md"]
   end
 
-  spec.add_dependency "cognito_idp", ">= 0.1.1"
+  spec.add_dependency "cognito_idp", "~> 1.0"
   spec.add_dependency "rails", ">= 7.0.0"
 end

--- a/spec/requests/cognito_idp_rails/sessions_spec.rb
+++ b/spec/requests/cognito_idp_rails/sessions_spec.rb
@@ -114,8 +114,8 @@ RSpec.describe "Sessions", type: :request do
       before do
         allow(client).to receive(:get_token)
           .with(grant_type: :authorization_code, code: code, redirect_uri: redirect_uri)
-          .and_yield(valid_token)
-        allow(client).to receive(:get_user_info).with(valid_token).and_yield(user_info)
+          .and_return(valid_token)
+        allow(client).to receive(:get_user_info).with(valid_token).and_return(user_info)
       end
 
       it "requests a token" do
@@ -151,12 +151,13 @@ RSpec.describe "Sessions", type: :request do
           end
         end
 
-        context "when user_info is not received" do
+        context "when get_user_info raises an error" do
           before do
             allow(client).to receive(:get_token)
               .with(grant_type: :authorization_code, code: code, redirect_uri: redirect_uri)
-              .and_yield(valid_token)
-            allow(client).to receive(:get_user_info).with(valid_token).and_return(nil)
+              .and_return(valid_token)
+            allow(client).to receive(:get_user_info).with(valid_token)
+              .and_raise(CognitoIdp::Error.new(error: "invalid_token", http_status: 401))
           end
 
           include_examples "unsuccessful login"
@@ -167,11 +168,11 @@ RSpec.describe "Sessions", type: :request do
         end
       end
 
-      context "when a token is not received" do
+      context "when get_token raises an error" do
         before do
           allow(client).to receive(:get_token)
             .with(grant_type: :authorization_code, code: code, redirect_uri: redirect_uri)
-            .and_return(nil)
+            .and_raise(CognitoIdp::Error.new(error: "invalid_grant", http_status: 400))
         end
 
         include_examples "unsuccessful login"


### PR DESCRIPTION
Replace block-yielding pattern in login_callback with direct return
values and rescue, matching cognito_idp 1.0's error-raising behaviour.
