### PR TITLE
chore(deps-dev): Bump rubocop-rspec to 3.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,4 +17,4 @@ gem "rspec-rails", "~> 6.1"
 
 gem "standard", "~> 1.32"
 
-gem "rubocop-rspec", "~> 2.25"
+gem "rubocop-rspec", "~> 3.0"


### PR DESCRIPTION
rubocop-rspec 2.x depends on rubocop-rspec_rails, which is incompatible
with rubocop 1.84+.
