### PR TITLE
fix: Clear OAuth state parameter after use

### DIFF
--- a/app/controllers/cognito_idp_rails/sessions_controller.rb
+++ b/app/controllers/cognito_idp_rails/sessions_controller.rb
@@ -9,6 +9,7 @@ module CognitoIdpRails
     end
 
     def login_callback
+      session.delete(:login_state)
       token = client.get_token(grant_type: :authorization_code, code: params[:code], redirect_uri: auth_login_callback_url)
       user_info = client.get_user_info(token)
       reset_session

--- a/spec/requests/cognito_idp_rails/sessions_spec.rb
+++ b/spec/requests/cognito_idp_rails/sessions_spec.rb
@@ -125,6 +125,12 @@ RSpec.describe "Sessions", type: :request do
           .with(grant_type: :authorization_code, code: code, redirect_uri: redirect_uri)
       end
 
+      it "clears the login state" do
+        get path
+
+        expect(session[:login_state]).to be_nil
+      end
+
       context "when a token is received" do
         it "requests user_info" do
           get path
@@ -162,6 +168,12 @@ RSpec.describe "Sessions", type: :request do
 
           include_examples "unsuccessful login"
 
+          it "clears the login state" do
+            state
+            get path
+            expect(session[:login_state]).to be_nil
+          end
+
           it "does not call back to after_login" do
             expect(after_login).not_to have_received(:call)
           end
@@ -176,6 +188,12 @@ RSpec.describe "Sessions", type: :request do
         end
 
         include_examples "unsuccessful login"
+
+        it "clears the login state" do
+          state
+          get path
+          expect(session[:login_state]).to be_nil
+        end
 
         it "does not request user_info" do
           expect(client).not_to have_received(:get_user_info).with(valid_token)


### PR DESCRIPTION
Prevent state replay by deleting login_state from the session at the
start of login_callback, ensuring it is consumed regardless of whether
the token exchange succeeds or fails.
