### PR TITLE
feat: Add on_login_error callback

### DIFF
--- a/app/controllers/cognito_idp_rails/sessions_controller.rb
+++ b/app/controllers/cognito_idp_rails/sessions_controller.rb
@@ -15,7 +15,8 @@ module CognitoIdpRails
       reset_session
       configuration.after_login.call(token, user_info, request)
       redirect_to configuration.after_login_route, notice: "You have been successfully logged in."
-    rescue CognitoIdp::Error
+    rescue CognitoIdp::Error => e
+      configuration.on_login_error.call(e, request)
       redirect_to configuration.after_login_route, notice: "Login failed."
     end
 

--- a/lib/cognito_idp_rails/configuration.rb
+++ b/lib/cognito_idp_rails/configuration.rb
@@ -1,13 +1,14 @@
 module CognitoIdpRails
   class Configuration
     attr_accessor :after_login_route, :after_logout_route, :domain, :client_id,
-      :client_secret, :after_login, :before_logout, :scope
+      :client_secret, :after_login, :before_logout, :on_login_error, :scope
 
     def initialize
       @after_login_route = "/"
       @after_logout_route = "/"
       @after_login = lambda { |token, user_info, request| }
       @before_logout = lambda { |request| }
+      @on_login_error = lambda { |error, request| }
     end
   end
 end

--- a/spec/cognito_idp_rails/configuration_spec.rb
+++ b/spec/cognito_idp_rails/configuration_spec.rb
@@ -119,6 +119,22 @@ RSpec.describe CognitoIdpRails::Configuration do
     end
   end
 
+  describe "#on_login_error" do
+    subject(:on_login_error) { configuration.on_login_error }
+
+    it { is_expected.to be_a(Proc) }
+
+    context "when specified" do
+      before do
+        configuration.on_login_error = new_on_login_error
+      end
+
+      let(:new_on_login_error) { instance_double(Proc) }
+
+      it { is_expected.to eq(new_on_login_error) }
+    end
+  end
+
   describe "#scope" do
     subject(:scope) { configuration.scope }
 

--- a/spec/requests/cognito_idp_rails/sessions_spec.rb
+++ b/spec/requests/cognito_idp_rails/sessions_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe "Sessions", type: :request do
     allow(after_login).to receive(:call)
     allow(configuration).to receive(:before_logout).and_return(before_logout)
     allow(before_logout).to receive(:call)
+    allow(configuration).to receive(:on_login_error).and_return(on_login_error)
+    allow(on_login_error).to receive(:call)
   end
 
   let(:configuration) { CognitoIdpRails.configuration }
@@ -20,6 +22,9 @@ RSpec.describe "Sessions", type: :request do
   end
   let(:before_logout) do
     lambda { |session| }
+  end
+  let(:on_login_error) do
+    lambda { |error, request| }
   end
 
   describe "GET /login" do
@@ -158,12 +163,14 @@ RSpec.describe "Sessions", type: :request do
         end
 
         context "when get_user_info raises an error" do
+          let(:error) { CognitoIdp::Error.new(error: "invalid_token", http_status: 401) }
+
           before do
             allow(client).to receive(:get_token)
               .with(grant_type: :authorization_code, code: code, redirect_uri: redirect_uri)
               .and_return(valid_token)
             allow(client).to receive(:get_user_info).with(valid_token)
-              .and_raise(CognitoIdp::Error.new(error: "invalid_token", http_status: 401))
+              .and_raise(error)
           end
 
           include_examples "unsuccessful login"
@@ -174,6 +181,12 @@ RSpec.describe "Sessions", type: :request do
             expect(session[:login_state]).to be_nil
           end
 
+          it "calls back to on_login_error" do
+            state
+            get path
+            expect(on_login_error).to have_received(:call).with(error, ActionDispatch::Request)
+          end
+
           it "does not call back to after_login" do
             expect(after_login).not_to have_received(:call)
           end
@@ -181,10 +194,12 @@ RSpec.describe "Sessions", type: :request do
       end
 
       context "when get_token raises an error" do
+        let(:error) { CognitoIdp::Error.new(error: "invalid_grant", http_status: 400) }
+
         before do
           allow(client).to receive(:get_token)
             .with(grant_type: :authorization_code, code: code, redirect_uri: redirect_uri)
-            .and_raise(CognitoIdp::Error.new(error: "invalid_grant", http_status: 400))
+            .and_raise(error)
         end
 
         include_examples "unsuccessful login"
@@ -193,6 +208,12 @@ RSpec.describe "Sessions", type: :request do
           state
           get path
           expect(session[:login_state]).to be_nil
+        end
+
+        it "calls back to on_login_error" do
+          state
+          get path
+          expect(on_login_error).to have_received(:call).with(error, ActionDispatch::Request)
         end
 
         it "does not request user_info" do


### PR DESCRIPTION
Provides a configurable callback invoked with the error and request
when token exchange or user info retrieval fails, allowing host apps
to log, alert, or instrument auth failures as needed.
