### PR TITLE
feat: Validate required configuration

### DIFF
--- a/lib/cognito_idp_rails.rb
+++ b/lib/cognito_idp_rails.rb
@@ -3,6 +3,8 @@ require "cognito_idp_rails/version"
 require "cognito_idp"
 
 module CognitoIdpRails
+  class ConfigurationError < StandardError; end
+
   autoload :Configuration, "cognito_idp_rails/configuration"
 
   module Routing
@@ -11,11 +13,14 @@ module CognitoIdpRails
 
   class << self
     def client
-      @client ||= CognitoIdp::Client.new(
-        client_id: configuration.client_id,
-        client_secret: configuration.client_secret,
-        domain: configuration.domain
-      )
+      @client ||= begin
+        configuration.validate!
+        CognitoIdp::Client.new(
+          client_id: configuration.client_id,
+          client_secret: configuration.client_secret,
+          domain: configuration.domain
+        )
+      end
     end
 
     def configuration

--- a/lib/cognito_idp_rails/configuration.rb
+++ b/lib/cognito_idp_rails/configuration.rb
@@ -3,12 +3,21 @@ module CognitoIdpRails
     attr_accessor :after_login_route, :after_logout_route, :domain, :client_id,
       :client_secret, :after_login, :before_logout, :on_login_error, :scope
 
+    REQUIRED_ATTRIBUTES = %i[domain client_id client_secret].freeze
+
     def initialize
       @after_login_route = "/"
       @after_logout_route = "/"
       @after_login = lambda { |token, user_info, request| }
       @before_logout = lambda { |request| }
       @on_login_error = lambda { |error, request| }
+    end
+
+    def validate!
+      missing = REQUIRED_ATTRIBUTES.select { |attr| public_send(attr).nil? }
+      return if missing.empty?
+
+      raise ConfigurationError, "Missing required configuration: #{missing.join(", ")}"
     end
   end
 end

--- a/spec/cognito_idp_rails/configuration_spec.rb
+++ b/spec/cognito_idp_rails/configuration_spec.rb
@@ -135,6 +135,41 @@ RSpec.describe CognitoIdpRails::Configuration do
     end
   end
 
+  describe "#validate!" do
+    context "when all required attributes are set" do
+      before do
+        configuration.domain = "auth.example.com"
+        configuration.client_id = "client-1"
+        configuration.client_secret = "secret"
+      end
+
+      it "does not raise" do
+        expect { configuration.validate! }.not_to raise_error
+      end
+    end
+
+    context "when domain is missing" do
+      before do
+        configuration.client_id = "client-1"
+        configuration.client_secret = "secret"
+      end
+
+      it "raises a ConfigurationError" do
+        expect { configuration.validate! }.to raise_error(
+          CognitoIdpRails::ConfigurationError, "Missing required configuration: domain"
+        )
+      end
+    end
+
+    context "when multiple attributes are missing" do
+      it "raises a ConfigurationError listing all missing attributes" do
+        expect { configuration.validate! }.to raise_error(
+          CognitoIdpRails::ConfigurationError, "Missing required configuration: domain, client_id, client_secret"
+        )
+      end
+    end
+  end
+
   describe "#scope" do
     subject(:scope) { configuration.scope }
 


### PR DESCRIPTION
Raises CognitoIdpRails::ConfigurationError with a clear message
listing missing attributes when domain, client_id, or client_secret
are not set, triggered on first client access.
