### PR TITLE
feat: Default OAuth scope to "openid"

### DIFF
--- a/lib/cognito_idp_rails/configuration.rb
+++ b/lib/cognito_idp_rails/configuration.rb
@@ -11,6 +11,7 @@ module CognitoIdpRails
       @after_login = lambda { |token, user_info, request| }
       @before_logout = lambda { |request| }
       @on_login_error = lambda { |error, request| }
+      @scope = "openid"
     end
 
     def validate!

--- a/spec/cognito_idp_rails/configuration_spec.rb
+++ b/spec/cognito_idp_rails/configuration_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe CognitoIdpRails::Configuration do
   describe "#scope" do
     subject(:scope) { configuration.scope }
 
-    it { is_expected.to be_nil }
+    it { is_expected.to eq("openid") }
 
     context "when specified" do
       before do


### PR DESCRIPTION
The login callback calls get_user_info which requires the openid scope.
Defaulting to "openid" ensures the gem works correctly out of the box.
